### PR TITLE
Incorrect uname in the scripts

### DIFF
--- a/linux/s1-agent-install-mgmt-api.sh
+++ b/linux/s1-agent-install-mgmt-api.sh
@@ -128,7 +128,7 @@ function check_api_response () {
 
 
 function find_agent_info_by_architecture () {
-    OS_ARCH=$(uname -p)
+    OS_ARCH=$(uname -m)
     if [[ $OS_ARCH == "aarch64" ]]; then
         for i in {0..20}; do
             FN=$(cat response.txt | jq -r ".data[$i].fileName")

--- a/linux/s1-agent-install-repo.sh
+++ b/linux/s1-agent-install-repo.sh
@@ -130,7 +130,7 @@ function check_args () {
 
 # Determine the CPU architecture
 function find_agent_info_by_architecture () {
-    OS_ARCH=$(uname -p)
+    OS_ARCH=$(uname -m)
     if [[ $OS_ARCH == "aarch64" ]]; then
         printf "\n${Yellow}INFO:  CPU Architecture is $OS_ARCH... ${Color_Off} \n\n" 
     elif [[ $OS_ARCH == "x86_64" || $OS_ARCH == "unknown" ]]; then


### PR DESCRIPTION
`uname -m` is the correct way to get the platform architecture as used in the scripts.  `uname -p` is documented as "not portable".  On both debian and fedora, it returns "unknown" on an aarch64 machine.  I've tested the change in GCP images on both debian and fedora.  