### PR TITLE
fix(security): validate API-controlled installer metadata (IT07)

### DIFF
--- a/aws/ec2-image-builder/s1-agent-helper-ec2-image-builder.sh
+++ b/aws/ec2-image-builder/s1-agent-helper-ec2-image-builder.sh
@@ -31,6 +31,7 @@ PACKAGE_MANAGER=''
 AGENT_INSTALL_SYNTAX=''
 AGENT_FILE_NAME=''
 AGENT_DOWNLOAD_LINK=''
+AGENT_FILE_SHA1=''
 VERSION_COMPARE_RESULT=''
 
 
@@ -207,6 +208,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN == *$OS_ARCH* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -216,6 +218,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN != *"aarch"* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -231,6 +234,55 @@ function find_agent_info_by_architecture () {
 }
 
 
+# Validate agent metadata returned by the management API before using it as a
+# path component or shell argument.  Without these checks, a tampered API
+# response could traverse out of /tmp, inject curl flags, or pass an option
+# through to dpkg/rpm.
+function validate_agent_info () {
+    # File name must be a plain basename, no path separators or parent refs,
+    # and must end in .deb or .rpm.
+    if [[ "$AGENT_FILE_NAME" != "$(basename -- "$AGENT_FILE_NAME")" ]] \
+        || [[ "$AGENT_FILE_NAME" == *".."* ]] \
+        || ! [[ "$AGENT_FILE_NAME" =~ ^[A-Za-z0-9._-]+\.(deb|rpm)$ ]]; then
+        printf "\nERROR:  Refusing to use untrusted agent file name returned by API: %s\n" "$AGENT_FILE_NAME"
+        exit 1
+    fi
+
+    # Download URL must be HTTPS so a tampered API response cannot redirect to
+    # a non-TLS or non-HTTP scheme (file:, javascript:, etc.).  The host is not
+    # restricted because SentinelOne may serve packages from a CDN; integrity
+    # is enforced via the SHA1 check below instead.
+    if ! [[ "$AGENT_DOWNLOAD_LINK" =~ ^https://[^[:space:]]+$ ]]; then
+        printf "\nERROR:  Refusing to download from non-HTTPS agent download link: %s\n" "$AGENT_DOWNLOAD_LINK"
+        exit 1
+    fi
+
+    # SHA1 from the API must be a 40-character hex string.  This is the value
+    # we will verify the downloaded file against.
+    if ! [[ "$AGENT_FILE_SHA1" =~ ^[a-fA-F0-9]{40}$ ]]; then
+        printf "\nERROR:  Refusing to install agent without a valid SHA1 from the API: %s\n" "$AGENT_FILE_SHA1"
+        exit 1
+    fi
+}
+
+
+# Verify the downloaded package matches the SHA1 returned by the management
+# API.  Catches transport corruption / partial downloads and binds the
+# filename to its contents at install time (matches the official S1 Ansible
+# role's behavior).
+function verify_agent_sha1 () {
+    local expected actual
+    expected=$(printf '%s' "$AGENT_FILE_SHA1" | tr '[:upper:]' '[:lower:]')
+    actual=$(sha1sum -- "/tmp/$AGENT_FILE_NAME" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    if [[ "$actual" != "$expected" ]]; then
+        printf "\nERROR:  SHA1 mismatch on downloaded agent.  expected=%s actual=%s\n" "$expected" "$actual"
+        rm -f -- "/tmp/$AGENT_FILE_NAME"
+        exit 1
+    fi
+    printf "\nINFO:  SHA1 verified: %s \n" "$actual"
+}
+
+
 check_root
 detect_pkg_mgr_info
 awscli_check $PACKAGE_MANAGER
@@ -241,18 +293,20 @@ jq_check $PACKAGE_MANAGER
 sudo curl -sH "Accept: application/json" -H "Authorization: ApiToken $API_KEY" "$S1_MGMT_URL$API_ENDPOINT?countOnly=false&packageTypes=Agent&osTypes=linux&sortBy=createdAt&limit=20&fileExtension=$FILE_EXTENSION&sortOrder=desc" > response.txt
 check_api_response
 find_agent_info_by_architecture
-printf "\nINFO:  Downloading $AGENT_FILE_NAME \n"
-sudo curl -sH "Authorization: ApiToken $API_KEY" $AGENT_DOWNLOAD_LINK -o /tmp/$AGENT_FILE_NAME
-printf "\nINFO:  Installing S1 Agent: $(echo "sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME") \n"
-sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME
+validate_agent_info
+printf "\nINFO:  Downloading %s \n" "$AGENT_FILE_NAME"
+sudo curl -sH "Authorization: ApiToken $API_KEY" -o "/tmp/$AGENT_FILE_NAME" -- "$AGENT_DOWNLOAD_LINK"
+verify_agent_sha1
+printf "\nINFO:  Installing S1 Agent: sudo %s -- /tmp/%s \n" "$AGENT_INSTALL_SYNTAX" "$AGENT_FILE_NAME"
+sudo $AGENT_INSTALL_SYNTAX -- "/tmp/$AGENT_FILE_NAME"
 printf "\nINFO:  Setting Site Token... \n"
-sudo /opt/sentinelone/bin/sentinelctl management token set $SITE_TOKEN
+sudo /opt/sentinelone/bin/sentinelctl management token set "$SITE_TOKEN"
 
 
 #clean up files..
 printf "\nINFO:  Cleaning up files... \n"
 rm -f response.txt
 rm -f versions.txt
-rm -f /tmp/$AGENT_FILE_NAME
+rm -f -- "/tmp/$AGENT_FILE_NAME"
 
 printf "\nSUCCESS:  Finished installing SentinelOne Agent. \n\n"

--- a/linux/s1-agent-helper-mgmt-api-aws-ssm.sh
+++ b/linux/s1-agent-helper-mgmt-api-aws-ssm.sh
@@ -33,6 +33,7 @@ PACKAGE_MANAGER=''
 AGENT_INSTALL_SYNTAX=''
 AGENT_FILE_NAME=''
 AGENT_DOWNLOAD_LINK=''
+AGENT_FILE_SHA1=''
 VERSION_COMPARE_RESULT=''
 
 Color_Off='\033[0m'       # Text Resets
@@ -198,6 +199,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN == *$OS_ARCH* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -207,6 +209,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN != *"aarch"* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -219,6 +222,49 @@ function find_agent_info_by_architecture () {
         echo ""
         exit 1
     fi
+}
+
+
+# Validate agent metadata returned by the management API before using it as a
+# path component or shell argument.  Without these checks, a tampered API
+# response could traverse out of /tmp, inject curl flags, or pass an option
+# through to dpkg/rpm.
+function validate_agent_info () {
+    if [[ "$AGENT_FILE_NAME" != "$(basename -- "$AGENT_FILE_NAME")" ]] \
+        || [[ "$AGENT_FILE_NAME" == *".."* ]] \
+        || ! [[ "$AGENT_FILE_NAME" =~ ^[A-Za-z0-9._-]+\.(deb|rpm)$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to use untrusted agent file name returned by API: %s ${Color_Off}\n" "$AGENT_FILE_NAME"
+        exit 1
+    fi
+
+    # Download URL must be HTTPS so a tampered API response cannot redirect to
+    # a non-TLS or non-HTTP scheme.  The host is not restricted because
+    # SentinelOne may serve packages from a CDN; integrity is enforced via
+    # the SHA1 check below instead.
+    if ! [[ "$AGENT_DOWNLOAD_LINK" =~ ^https://[^[:space:]]+$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to download from non-HTTPS agent download link: %s ${Color_Off}\n" "$AGENT_DOWNLOAD_LINK"
+        exit 1
+    fi
+
+    if ! [[ "$AGENT_FILE_SHA1" =~ ^[a-fA-F0-9]{40}$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to install agent without a valid SHA1 from the API: %s ${Color_Off}\n" "$AGENT_FILE_SHA1"
+        exit 1
+    fi
+}
+
+
+# Verify the downloaded package matches the SHA1 returned by the management
+# API.
+function verify_agent_sha1 () {
+    local expected actual
+    expected=$(printf '%s' "$AGENT_FILE_SHA1" | tr '[:upper:]' '[:lower:]')
+    actual=$(sha1sum -- "/tmp/$AGENT_FILE_NAME" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    if [[ "$actual" != "$expected" ]]; then
+        printf "\n${Red}ERROR:  SHA1 mismatch on downloaded agent.  expected=%s actual=%s ${Color_Off}\n" "$expected" "$actual"
+        rm -f -- "/tmp/$AGENT_FILE_NAME"
+        exit 1
+    fi
+    printf "\n${Yellow}INFO:  SHA1 verified: %s ${Color_Off}\n" "$actual"
 }
 
 
@@ -256,12 +302,14 @@ aws_check $PACKAGE_MANAGER
 sudo curl -sH "Accept: application/json" -H "Authorization: ApiToken $API_TOKEN" "$S1_MGMT_URL$API_ENDPOINT?sortOrder=desc&fileExtension=$FILE_EXTENSION&limit=20&sortBy=version&status=$VERSION_STATUS&platformTypes=linux" > response.txt
 check_api_response
 find_agent_info_by_architecture
-printf "\n${Yellow}INFO:  Downloading $AGENT_FILE_NAME ${Color_Off}\n"
-sudo curl -sH "Authorization: ApiToken $API_TOKEN" $AGENT_DOWNLOAD_LINK -o /tmp/$AGENT_FILE_NAME
-printf "\n${Yellow}INFO:  Installing S1 Agent: $(echo "sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME") ${Color_Off}\n"
-sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME
+validate_agent_info
+printf "\n${Yellow}INFO:  Downloading %s ${Color_Off}\n" "$AGENT_FILE_NAME"
+sudo curl -sH "Authorization: ApiToken $API_TOKEN" -o "/tmp/$AGENT_FILE_NAME" -- "$AGENT_DOWNLOAD_LINK"
+verify_agent_sha1
+printf "\n${Yellow}INFO:  Installing S1 Agent: sudo %s -- /tmp/%s ${Color_Off}\n" "$AGENT_INSTALL_SYNTAX" "$AGENT_FILE_NAME"
+sudo $AGENT_INSTALL_SYNTAX -- "/tmp/$AGENT_FILE_NAME"
 printf "\n${Yellow}INFO:  Setting Site Token... ${Color_Off}\n"
-sudo /opt/sentinelone/bin/sentinelctl management token set $SITE_TOKEN
+sudo /opt/sentinelone/bin/sentinelctl management token set "$SITE_TOKEN"
 printf "\n${Yellow}INFO:  Starting Agent... ${Color_Off}\n"
 sudo /opt/sentinelone/bin/sentinelctl control start
 
@@ -269,6 +317,6 @@ sudo /opt/sentinelone/bin/sentinelctl control start
 printf "\n${Yellow}INFO:  Cleaning up files... ${Color_Off}\n"
 rm -f response.txt
 rm -f versions.txt
-rm -f /tmp/$AGENT_FILE_NAME
+rm -f -- "/tmp/$AGENT_FILE_NAME"
 
 printf "\n${Green}SUCCESS:  Finished installing SentinelOne Agent. ${Color_Off}\n\n"

--- a/linux/s1-agent-install-mgmt-api.sh
+++ b/linux/s1-agent-install-mgmt-api.sh
@@ -22,6 +22,7 @@ PACKAGE_MANAGER=''
 AGENT_INSTALL_SYNTAX=''
 AGENT_FILE_NAME=''
 AGENT_DOWNLOAD_LINK=''
+AGENT_FILE_SHA1=''
 VERSION_COMPARE_RESULT=''
 
 Color_Off='\033[0m'       # Text Resets
@@ -135,6 +136,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN == *$OS_ARCH* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -144,6 +146,7 @@ function find_agent_info_by_architecture () {
             if [[ $FN != *"aarch"* ]]; then
                 AGENT_FILE_NAME=$(cat response.txt | jq -r ".data[$i].fileName")
                 AGENT_DOWNLOAD_LINK=$(cat response.txt | jq -r ".data[$i].link")
+                AGENT_FILE_SHA1=$(cat response.txt | jq -r ".data[$i].sha1")
                 break
             fi
         done
@@ -156,6 +159,49 @@ function find_agent_info_by_architecture () {
         echo ""
         exit 1
     fi
+}
+
+
+# Validate agent metadata returned by the management API before using it as a
+# path component or shell argument.  Without these checks, a tampered API
+# response could traverse out of /tmp, inject curl flags, or pass an option
+# through to dpkg/rpm.
+function validate_agent_info () {
+    if [[ "$AGENT_FILE_NAME" != "$(basename -- "$AGENT_FILE_NAME")" ]] \
+        || [[ "$AGENT_FILE_NAME" == *".."* ]] \
+        || ! [[ "$AGENT_FILE_NAME" =~ ^[A-Za-z0-9._-]+\.(deb|rpm)$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to use untrusted agent file name returned by API: %s ${Color_Off}\n" "$AGENT_FILE_NAME"
+        exit 1
+    fi
+
+    # Download URL must be HTTPS so a tampered API response cannot redirect to
+    # a non-TLS or non-HTTP scheme.  The host is not restricted because
+    # SentinelOne may serve packages from a CDN; integrity is enforced via
+    # the SHA1 check below instead.
+    if ! [[ "$AGENT_DOWNLOAD_LINK" =~ ^https://[^[:space:]]+$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to download from non-HTTPS agent download link: %s ${Color_Off}\n" "$AGENT_DOWNLOAD_LINK"
+        exit 1
+    fi
+
+    if ! [[ "$AGENT_FILE_SHA1" =~ ^[a-fA-F0-9]{40}$ ]]; then
+        printf "\n${Red}ERROR:  Refusing to install agent without a valid SHA1 from the API: %s ${Color_Off}\n" "$AGENT_FILE_SHA1"
+        exit 1
+    fi
+}
+
+
+# Verify the downloaded package matches the SHA1 returned by the management
+# API.
+function verify_agent_sha1 () {
+    local expected actual
+    expected=$(printf '%s' "$AGENT_FILE_SHA1" | tr '[:upper:]' '[:lower:]')
+    actual=$(sha1sum -- "/tmp/$AGENT_FILE_NAME" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    if [[ "$actual" != "$expected" ]]; then
+        printf "\n${Red}ERROR:  SHA1 mismatch on downloaded agent.  expected=%s actual=%s ${Color_Off}\n" "$expected" "$actual"
+        rm -f -- "/tmp/$AGENT_FILE_NAME"
+        exit 1
+    fi
+    printf "\n${Yellow}INFO:  SHA1 verified: %s ${Color_Off}\n" "$actual"
 }
 
 
@@ -192,12 +238,14 @@ jq_check $PACKAGE_MANAGER
 sudo curl -sH "Accept: application/json" -H "Authorization: ApiToken $API_TOKEN" "$S1_MGMT_URL$API_ENDPOINT?sortOrder=desc&fileExtension=$FILE_EXTENSION&limit=20&sortBy=version&status=$VERSION_STATUS&platformTypes=linux" > response.txt
 check_api_response
 find_agent_info_by_architecture
-printf "\n${Yellow}INFO:  Downloading $AGENT_FILE_NAME ${Color_Off}\n"
-sudo curl -sH "Authorization: ApiToken $API_TOKEN" $AGENT_DOWNLOAD_LINK -o /tmp/$AGENT_FILE_NAME
-printf "\n${Yellow}INFO:  Installing S1 Agent: $(echo "sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME") ${Color_Off}\n"
-sudo $AGENT_INSTALL_SYNTAX /tmp/$AGENT_FILE_NAME
+validate_agent_info
+printf "\n${Yellow}INFO:  Downloading %s ${Color_Off}\n" "$AGENT_FILE_NAME"
+sudo curl -sH "Authorization: ApiToken $API_TOKEN" -o "/tmp/$AGENT_FILE_NAME" -- "$AGENT_DOWNLOAD_LINK"
+verify_agent_sha1
+printf "\n${Yellow}INFO:  Installing S1 Agent: sudo %s -- /tmp/%s ${Color_Off}\n" "$AGENT_INSTALL_SYNTAX" "$AGENT_FILE_NAME"
+sudo $AGENT_INSTALL_SYNTAX -- "/tmp/$AGENT_FILE_NAME"
 printf "\n${Yellow}INFO:  Setting Site Token... ${Color_Off}\n"
-sudo /opt/sentinelone/bin/sentinelctl management token set $SITE_TOKEN
+sudo /opt/sentinelone/bin/sentinelctl management token set "$SITE_TOKEN"
 printf "\n${Yellow}INFO:  Starting Agent... ${Color_Off}\n"
 sudo /opt/sentinelone/bin/sentinelctl control start
 
@@ -205,6 +253,6 @@ sudo /opt/sentinelone/bin/sentinelctl control start
 printf "\n${Yellow}INFO:  Cleaning up files... ${Color_Off}\n"
 rm -f response.txt
 rm -f versions.txt
-rm -f /tmp/$AGENT_FILE_NAME
+rm -f -- "/tmp/$AGENT_FILE_NAME"
 
 printf "\n${Green}SUCCESS:  Finished installing SentinelOne Agent. ${Color_Off}\n\n"

--- a/windows/s1-agent-helper-mgmt-api-aws-ssm.ps1
+++ b/windows/s1-agent-helper-mgmt-api-aws-ssm.ps1
@@ -13,6 +13,7 @@
  $api_endpoint = "/web/api/v2.1/update/agent/packages"
  $agent_file_name = ""
  $agent_download_link = ""
+ $agent_file_sha1 = ""
  $agent_package_major_version = ""
  
  # Basic sanity checks for input parameters
@@ -69,6 +70,7 @@
      if ($package.status -like "$version_status*") {
          $agent_download_link = $package.link
          $agent_file_name = $package.fileName
+         $agent_file_sha1 = $package.sha1
          $agent_package_major_version = $package.majorVersion
          break
      }
@@ -78,33 +80,80 @@
  Write-Output "Agent File Name:     $agent_file_name"
  Write-Output "Agent Download Link: $agent_download_link"
  write-output ""
- 
+
+ # Validate the API-supplied file name before using it as a path component.
+ # Reject path separators, drive letters, parent-directory references, and any
+ # character that is not part of a plain installer file name.
+ if ([string]::IsNullOrEmpty($agent_file_name) -or
+     $agent_file_name -notmatch '^[A-Za-z0-9._-]+\.exe$') {
+     Write-Output "ERROR: Refusing to use untrusted agent file name returned by API: $agent_file_name"
+     exit 1
+ }
+
+ # Require HTTPS so a tampered API response cannot downgrade the download to a
+ # non-TLS scheme.  The host is not restricted because SentinelOne may serve
+ # packages from a CDN; integrity is enforced via the SHA1 check below instead.
+ $agent_download_uri = $null
+ try { $agent_download_uri = [System.Uri]$agent_download_link } catch {}
+ if ($null -eq $agent_download_uri -or $agent_download_uri.Scheme -ne 'https') {
+     Write-Output "ERROR: Refusing to download from non-HTTPS agent download link: $agent_download_link"
+     exit 1
+ }
+
+ # SHA1 from the API must be a 40-character hex string.  This is the value the
+ # downloaded file is verified against before execution.
+ if ([string]::IsNullOrEmpty($agent_file_sha1) -or
+     $agent_file_sha1 -notmatch '^[a-fA-F0-9]{40}$') {
+     Write-Output "ERROR: Refusing to install agent without a valid SHA1 from the API: $agent_file_sha1"
+     exit 1
+ }
+
+ # Resolve the destination path and confirm it stays inside $env:TEMP.
+ $temp_dir   = [System.IO.Path]::GetFullPath($env:TEMP)
+ $agent_path = [System.IO.Path]::GetFullPath((Join-Path -Path $temp_dir -ChildPath $agent_file_name))
+ if (-not $agent_path.StartsWith($temp_dir + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+     Write-Output "ERROR: Resolved agent path escapes TEMP directory: $agent_path"
+     exit 1
+ }
+
  # Now that we have the download link and file name.  Download the package to a TEMP directory.
  $wc = New-Object System.Net.WebClient
  $wc.Headers['Authorization'] = "APIToken $api_key"
- $wc.DownloadFile($agent_download_link, "$env:TEMP\$agent_file_name")
- 
+ $wc.DownloadFile($agent_download_uri, $agent_path)
+
+ # Verify the downloaded file matches the SHA1 returned by the management API.
+ # Catches transport corruption / partial downloads and binds the file name to
+ # its contents at install time.
+ $expected_sha1 = $agent_file_sha1.ToLowerInvariant()
+ $actual_sha1   = (Get-FileHash -Path $agent_path -Algorithm SHA1).Hash.ToLowerInvariant()
+ if ($actual_sha1 -ne $expected_sha1) {
+     Write-Output "ERROR: SHA1 mismatch on downloaded agent. expected=$expected_sha1 actual=$actual_sha1"
+     Remove-Item -Path $agent_path -Force -ErrorAction SilentlyContinue
+     exit 1
+ }
+ Write-Output "INFO: SHA1 verified: $actual_sha1"
+
  # If the agent package is version 22.1+, use the new CLI installation syntax
  if ($agent_package_major_version -ge "22.1") {
      # Execute using newer cli flags
      if($auto_reboot -eq "True") {
          # Execute the package with the quiet option and force restart
-         & "$env:TEMP\$agent_file_name" -t $site_token -q -b
+         & $agent_path -t $site_token -q -b
      }
      else {
          # Execute the package with the quiet option and do NOT restart
-         & "$env:TEMP\$agent_file_name" -t $site_token -q
+         & $agent_path -t $site_token -q
      }
  }
  else {
      #Execute the older EXE package
      if($auto_reboot -eq "True") {
          # Execute the package with the quiet option and force restart
-         & "$env:TEMP\$agent_file_name" /SITE_TOKEN=$site_token /quiet /reboot
+         & $agent_path /SITE_TOKEN=$site_token /quiet /reboot
      }
      else {
          # Execute the package with the quiet option and do NOT restart
-         & "$env:TEMP\$agent_file_name" /SITE_TOKEN=$site_token /quiet /norestart
+         & $agent_path /SITE_TOKEN=$site_token /quiet /norestart
      }
- } 
+ }
  

--- a/windows/s1-agent-install-mgmt-api.ps1
+++ b/windows/s1-agent-install-mgmt-api.ps1
@@ -22,6 +22,7 @@ Write-Output "mgmt url:            $s1_mgmt_url"
 $api_endpoint = "/web/api/v2.1/update/agent/packages"
 $agent_file_name = ""
 $agent_download_link = ""
+$agent_file_sha1 = ""
 $agent_package_major_version = ""
 
 # Basic sanity checks for input parameters
@@ -78,6 +79,7 @@ foreach ($package in $packages) {
     if ($package.status -like "$version_status*") {
         $agent_download_link = $package.link
         $agent_file_name = $package.fileName
+        $agent_file_sha1 = $package.sha1
         $agent_package_major_version = $package.majorVersion
         break
     }
@@ -88,23 +90,70 @@ Write-Output "Agent File Name:     $agent_file_name"
 Write-Output "Agent Download Link: $agent_download_link"
 write-output ""
 
+# Validate the API-supplied file name before using it as a path component.
+# Reject path separators, drive letters, parent-directory references, and any
+# character that is not part of a plain installer file name.
+if ([string]::IsNullOrEmpty($agent_file_name) -or
+    $agent_file_name -notmatch '^[A-Za-z0-9._-]+\.exe$') {
+    Write-Output "ERROR: Refusing to use untrusted agent file name returned by API: $agent_file_name"
+    exit 1
+}
+
+# Require HTTPS so a tampered API response cannot downgrade the download to a
+# non-TLS scheme.  The host is not restricted because SentinelOne may serve
+# packages from a CDN; integrity is enforced via the SHA1 check below instead.
+$agent_download_uri = $null
+try { $agent_download_uri = [System.Uri]$agent_download_link } catch {}
+if ($null -eq $agent_download_uri -or $agent_download_uri.Scheme -ne 'https') {
+    Write-Output "ERROR: Refusing to download from non-HTTPS agent download link: $agent_download_link"
+    exit 1
+}
+
+# SHA1 from the API must be a 40-character hex string.  This is the value the
+# downloaded file is verified against before execution.
+if ([string]::IsNullOrEmpty($agent_file_sha1) -or
+    $agent_file_sha1 -notmatch '^[a-fA-F0-9]{40}$') {
+    Write-Output "ERROR: Refusing to install agent without a valid SHA1 from the API: $agent_file_sha1"
+    exit 1
+}
+
+# Resolve the destination path and confirm it stays inside $env:TEMP.
+$temp_dir   = [System.IO.Path]::GetFullPath($env:TEMP)
+$agent_path = [System.IO.Path]::GetFullPath((Join-Path -Path $temp_dir -ChildPath $agent_file_name))
+if (-not $agent_path.StartsWith($temp_dir + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+    Write-Output "ERROR: Resolved agent path escapes TEMP directory: $agent_path"
+    exit 1
+}
+
 # Now that we have the download link and file name.  Download the package to a TEMP directory.
 $wc = New-Object System.Net.WebClient
 $wc.Headers['Authorization'] = "APIToken $api_key"
-$wc.DownloadFile($agent_download_link, "$env:TEMP\$agent_file_name")
+$wc.DownloadFile($agent_download_uri, $agent_path)
+
+# Verify the downloaded file matches the SHA1 returned by the management API.
+# Catches transport corruption / partial downloads and binds the file name to
+# its contents at install time.
+$expected_sha1 = $agent_file_sha1.ToLowerInvariant()
+$actual_sha1   = (Get-FileHash -Path $agent_path -Algorithm SHA1).Hash.ToLowerInvariant()
+if ($actual_sha1 -ne $expected_sha1) {
+    Write-Output "ERROR: SHA1 mismatch on downloaded agent. expected=$expected_sha1 actual=$actual_sha1"
+    Remove-Item -Path $agent_path -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+Write-Output "INFO: SHA1 verified: $actual_sha1"
 
 # If the agent package is version 22.1+, use the new CLI installation syntax
 if ($agent_package_major_version -ge "22.1") {
-    & "$env:TEMP\$agent_file_name" -t $site_token -q
+    & $agent_path -t $site_token -q
 }
 else {
     #Execute the older EXE package
     if($auto_reboot -eq "True") {
         # Execute the package with the quiet option and force restart
-        & "$env:TEMP\$agent_file_name" /SITE_TOKEN=$site_token /quiet /reboot
+        & $agent_path /SITE_TOKEN=$site_token /quiet /reboot
     }
     else {
         # Execute the package with the quiet option and do NOT restart
-        & "$env:TEMP\$agent_file_name" /SITE_TOKEN=$site_token /quiet /norestart
+        & $agent_path /SITE_TOKEN=$site_token /quiet /norestart
     }
 }


### PR DESCRIPTION
## Summary

Fixes two **Critical** findings (IT07):

- **API-controlled filename drives SYSTEM-level write-then-exec on Windows installer** — `windows/s1-agent-install-mgmt-api.ps1`, `windows/s1-agent-helper-mgmt-api-aws-ssm.ps1`
- **RCE as root via SSM installer trusting API-controlled download metadata** — `aws/ec2-image-builder/s1-agent-helper-ec2-image-builder.sh`, `linux/s1-agent-helper-mgmt-api-aws-ssm.sh`, `linux/s1-agent-install-mgmt-api.sh`

Root cause is the same in both: `fileName` and `link` from the `/web/api/v2.1/update/agent/packages` response are used as path components and command arguments without validation. A tampered or compromised API response could drop a file outside `%TEMP%` / `/tmp` via traversal in `fileName` and execute it as SYSTEM / root, smuggle flags into `curl` / `dpkg` / `rpm`, or redirect the download to an arbitrary URL.

## Mitigations (applied to all five installer scripts)

- **Filename whitelist** `^[A-Za-z0-9._-]+\.(exe|deb|rpm)$`, rejection of path separators and `..`. Verified compatible with the package-name patterns used by the official [`Sentinel-One/ansible_collection_s1agents`](https://github.com/Sentinel-One/ansible_collection_s1agents/blob/main/roles/s1_agent_download/tasks/release_named.yml) role (`^SentinelAgent[_-]linux`, `^SentinelOneInstaller`, etc.).
- **Path containment** — Windows resolves the destination via `Path.GetFullPath` and asserts it stays under `$env:TEMP`. Linux validates the basename and rejects `..`.
- **Argument hardening** — Linux scripts quote every use of `AGENT_FILE_NAME` / `AGENT_DOWNLOAD_LINK` and use `--` to terminate option parsing for `curl`, `dpkg`, and `rpm`.
- **HTTPS-only download** — `link` must use the `https://` scheme. Host is intentionally **not** restricted because SentinelOne may serve packages from a CDN; the official S1 Ansible role takes the same approach and enforces integrity via SHA1 instead.
- **SHA1 verification** — `sha1` field from the same API response is validated as a 40-character hex string, and the downloaded file's hash is verified with `sha1sum` (Linux) / `Get-FileHash` (Windows) before invoking the installer. Mismatched downloads are deleted and the script aborts.

## Compatibility / risk notes

- `sha1sum`, `awk`, `tr` are all coreutils — already required on every supported distro.
- `Get-FileHash` ships with PowerShell 4.0+ (Windows 8.1 / Server 2012 R2), same floor as the existing `Invoke-RestMethod` calls.
- The `sha1` field is documented and used by the official S1 Ansible role, so this piggybacks on existing API contract.
- If `sha1` is ever absent, the script aborts with a clear error rather than silently installing.

## Test plan

- [ ] Run `linux/s1-agent-install-mgmt-api.sh` against a real S1 tenant on a Debian/Ubuntu host; confirm SHA1-verified install succeeds.
- [ ] Run `linux/s1-agent-install-mgmt-api.sh` against a real S1 tenant on a RHEL/Amazon Linux host; confirm SHA1-verified install succeeds.
- [ ] Run `aws/ec2-image-builder/s1-agent-helper-ec2-image-builder.sh` end-to-end via EC2 Image Builder; confirm AMI build completes.
- [ ] Run `linux/s1-agent-helper-mgmt-api-aws-ssm.sh` via SSM Run Command on an EC2 instance with parameter store wired up; confirm install + start.
- [ ] Run `windows/s1-agent-install-mgmt-api.ps1` on Windows Server 2019/2022; confirm SHA1-verified install succeeds.
- [ ] Run `windows/s1-agent-helper-mgmt-api-aws-ssm.ps1` via SSM Run Command on a Windows EC2 instance; confirm install succeeds.
- [ ] Negative test: stub a response with a `fileName` containing `..\` — confirm script aborts before download.
- [ ] Negative test: stub a response with `link` set to `http://...` — confirm script aborts before download.
- [ ] Negative test: corrupt the downloaded file in a debugger / proxy and confirm the SHA1 verification step deletes it and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)