### PR TITLE
Change apt to apt-get for linux repo installation

### DIFF
--- a/linux/s1-agent-install-repo.sh
+++ b/linux/s1-agent-install-repo.sh
@@ -226,8 +226,8 @@ login ${S1_REPOSITORY_USERNAME}
 password ${S1_REPOSITORY_PASSWORD}
 EOF
     fi
-    apt update
-    apt install -y sentinelagent=${S1_AGENT_VERSION}
+    apt-get update
+    apt-get install -y sentinelagent=${S1_AGENT_VERSION}
 }
 
 


### PR DESCRIPTION
Prevents apt complaining "WARNING: apt does not have a stable CLI interface. Use with caution in scripts." when script is run without a tty attached